### PR TITLE
Chore: add logs for code generation and enforce verbose logs for evaluation

### DIFF
--- a/lcb_runner/evaluation/compute_code_generation_metrics.py
+++ b/lcb_runner/evaluation/compute_code_generation_metrics.py
@@ -59,6 +59,12 @@ def evaluate_generations_by_problem(args):
     debug: bool = args[2]
     timeout: int = args[3]
 
+    # NOTE: The debug flag is intentionally overridden to True here.
+    # We override the passed 'debug' argument to get detailed logging.
+    # LCB accepts a --debug flag, but it does not work for this function because its value is not passed down.
+    # This override also conveniently avoids the flag's unwanted side effects (like disabling parallelism).
+    debug = True
+
     res = []
     metadata = []
     for o_idx, o in enumerate(problem_generations):

--- a/lcb_runner/runner/base_runner.py
+++ b/lcb_runner/runner/base_runner.py
@@ -57,11 +57,13 @@ class BaseRunner(ABC):
 
         if cache is not None and prompt_cache in cache:
             if len(cache[prompt_cache]) == args.n:
+                print(f"Args: {args}, Prompt: {prompt_cache}\n(Cache Hit) Result: {cache[prompt_cache]}")
                 return cache[prompt_cache]
 
         result = call_method(prompt)
         assert len(result) == args.n
 
+        print(f"Args: {args}, Prompt: {prompt_cache}\nResult: {result}")
         return result
 
     def run_batch(self, prompts: list[str | list[dict[str, str]]]) -> list[list[str]]:


### PR DESCRIPTION
1. Add more logs to show the prompts and outputs
2. Enforce verbose output when evaluation the generated code

Here is a sample log from this MR. For brevity, I've limited the test to a single problem.
```
Loaded 175 problems
  0%|                                                                                                                                                                                                                         | 0/1 [00:00<?, ?it/s]
Args: Namespace(model='deepseek-ai/DeepSeek-V3', local_model_path=None, trust_remote_code=False, scenario=<Scenario.codegeneration: 'codegeneration'>, not_fast=False, release_version='release_v6', cot_code_execution=False, n=2, codegen_n=10, temperature=0.2, top_p=0.95, max_tokens=None, multiprocess=1, stop=['###'], continue_existing=False, continue_existing_with_eval=False, use_cache=False, cache_batch_size=100, debug=False, evaluate=True, num_process_evaluate=48, timeout=6, openai_timeout=21600, tensor_parallel_size=0, enable_prefix_caching=False, custom_output_file=None, custom_output_save_name=None, dtype='bfloat16', start_date=None, end_date=None, use_generic_openai_server=True), Prompt: [{"role": "system", "content": "You are an expert Python programmer. You will be given a question (problem specification) and will generate a correct Python program that matches the specification and passes all tests."}, {"role": "user", "content": "### Question:\nYou are given an array nums of n integers and an integer k.\nFor each subarray of nums, you can apply up to k operations on it. In each operation, you increment any element of the subarray by 1.\nNote that each subarray is considered independently, meaning changes made to one subarray do not persist to another.\nReturn the number of subarrays that you can make non-decreasing \u200b\u200b\u200b\u200b\u200bafter performing at most k operations.\nAn array is said to be non-decreasing if each element is greater than or equal to its previous element, if it exists.\n \nExample 1:\n\nInput: nums = [6,3,1,2,4,4], k = 7\nOutput: 17\nExplanation:\nOut of all 21 possible subarrays of nums, only the subarrays [6, 3, 1], [6, 3, 1, 2], [6, 3, 1, 2, 4] and [6, 3, 1, 2, 4, 4] cannot be made non-decreasing after applying up to k = 7 operations. Thus, the number of non-decreasing subarrays is 21 - 4 = 17.\n\nExample 2:\n\nInput: nums = [6,3,1,3,6], k = 4\nOutput: 12\nExplanation:\nThe subarray [3, 1, 3, 6] along with all subarrays of nums with three or fewer elements, except [6, 3, 1], can be made non-decreasing after k operations. There are 5 subarrays of a single element, 4 subarrays of two elements, and 2 subarrays of three elements except [6, 3, 1], so there are 1 + 5 + 4 + 2 = 12 subarrays that can be made non-decreasing.\n\n \nConstraints:\n\n1 <= nums.length <= 10^5\n1 <= nums[i] <= 10^9\n1 <= k <= 10^9\n\n### Format: You will use the following starter code to write the solution to the problem and enclose your code within delimiters.\n```python\nclass Solution:\n    def countNonDecreasingSubarrays(self, nums: List[int], k: int) -> int:\n        \n```\n\n### Answer: (use the provided format with backticks)\n\n"}]
Result: ["To solve this problem, we need to determine the number of subarrays in a given array that can be made non-decreasing by performing at most k operations, where each operation increments an element by 1. The key insight is that for a subarray to be made non-decreasing, the cumulative operations required to adjust each element to be at least as large as the previous element in the subarray should not exceed k.\n\n### Approach\n1. **Sliding Window Technique**: We will use a sliding window approach to efficiently check each possible subarray. The idea is to maintain a window [left, right] such that the operations needed to make the subarray from left to right non-decreasing is at most k. If the operations exceed k, we move the left pointer forward to reduce the required operations.\n\n2. **Operations Calculation**: For each new element added to the window (expanding the right pointer), we need to ensure that the previous elements in the window can be adjusted to form a non-decreasing sequence. The operations required for each element in the window can be derived by ensuring each element is at least as large as the previous element. The total operations required for the window is the sum of the differences between each element and the previous element whenever the current element is smaller than the previous one, adjusted for the length of the subarray.\n\n3. **Efficiency**: The naive approach would check every subarray, which is O(n^2), but with the sliding window technique, we can achieve O(n) time complexity by maintaining the window where the operations required are within k.\n\n### Solution Code\n```python\nclass Solution:\n    def countNonDecreasingSubarrays(self, nums: List[int], k: int) -> int:\n        n = len(nums)\n        total_subarrays = n * (n + 1) // 2\n        invalid_subarrays = 0\n        left = 0\n        \n        for right in range(1, n):\n            # Calculate the required operations for the new element nums[right]\n            # The operations needed is the sum of max(0, nums[i-1] - nums[i]) for i from left+1 to right\n            # But we need an efficient way to compute this as right expands\n            # We can keep track of the required operations incrementally\n            pass\n        \n        # Alternative approach: for each subarray, check if it can be made non-decreasing with <=k operations\n        # But O(n^2) is not feasible for n=1e5\n        # So need a sliding window approach\n        \n        # The correct approach is to find all subarrays where the sum of (max(0, a[i-1] - a[i])) for consecutive elements in the subarray multiplied by the number of times they affect the operations is <=k\n        # The sum is sum_{i=l+1 to r} max(0, a[i-1] - a[i]) * (r - i + 1)\n        # Because each deficit a[i-1] - a[i] must be added to a[i], a[i+1], ..., a[r] (i ranges from l+1 to r)\n        # So the total operations is sum_{i=l+1}^r (a[i-1] - a[i])*(r - i + 1) if a[i-1] > a[i]\n        \n        # Sliding window approach to count valid subarrays\n        res = 0\n        left = 0\n        current_ops = 0\n        \n        for right in range(n):\n            if right > 0:\n                # Calculate the additional operations needed when adding nums[right]\n                # The new pairs are (right-1, right)\n                if nums[right-1] > nums[right]:\n                    diff = nums[right-1] - nums[right]\n                    # For each segment that ends at right, the diff affects 1, 2, ..., (right - left) steps?\n                    # The number of new subarrays ending at right is (right - left)\n                    # So the total operations added is diff * (right - left)\n                    # Because for the subarray [left..right], [left+1..right], ..., [right-1..right], each requires diff operations for the last step\n                    # So total added operations is diff * (right - left)\n                    added_ops = diff * (right - left)\n                    current_ops += added_ops\n                    \n                    # Now, we need to move left forward until current_ops <=k\n                    while left <= right and current_ops > k:\n                        # When moving left forward, we need to subtract the ops that involved left\n                        # For the subarrays that start at left, and end at >= left+1, the ops contributed by nums[left] > nums[left+1]\n                        if left < right:\n                            if nums[left] > nums[left +1]:\n                                diff_left = nums[left] - nums[left +1]\n                                # The number of subarrays that start at left and end at any point >= left+1 is (right - left)\n                                subtracted_ops = diff_left * (right - left)\n                                current_ops -= subtracted_ops\n                        left += 1\n            # The number of valid subarrays ending at right is right - left + 1\n            res += right - left + 1\n        \n        return res\n```\n\nWait, but let's think again. The initial approach might not correctly handle the operations. Let me think of a better way.\n\nAlternative approach: For each subarray, the operations needed to make it non-decreasing is the sum of max(0, nums[i-1] - nums[i]) for each i in the subarray, but each such deficit must be propagated to all subsequent elements. For example, in the subarray [3, 1, 2], the operations are (3-1) = 2 for the first pair, then (1 + 2) must be >= 2, but 1 + 2 is 3 >= 2, so no additional operations. So total operations is 2.\n\nBut in the subarray [3, 1, 2, 4], the operations are 2 (3-1) + max(0, (1+2) - 2) = 2 + 1 = 3. So the operations are 3.\n\nBut how to compute this efficiently for all subarrays?\n\nThe total operations required for a subarray nums[l..r] is the sum for i from l+1 to r of max(0, nums[i-1] - nums[i]) * (r - i + 1). This is because each deficit at position i must be added to all elements from i to r.\n\nFor example, in the subarray [3, 1, 2], the operations are (3-1)*(2) + (1-2)*(1) if 1 < 2. But wait, no. The correct calculation is:\n\nFor the subarray [3, 1, 2]:\n\n- The first pair 3 > 1: deficit 2. This must be added to 1 and 2 (i.e., elements 1 and 2 must be increased by 2 each). So total operations 2*2 = 4.\n- Then, the next pair is (1+2) and 2. 3 >= 2, so no deficit. Total operations 4.\n\nBut the sample says that [3, 1, 2] can be made non-decreasing with 7 operations. But according to this calculation, it requires 4 operations, which is <=7, so it should be counted. But the sample says that [6,3,1,2,4,4] has 4 invalid subarrays, including [6,3,1], [6,3,1,2], etc. So perhaps the calculation is different.\n\nWait, let's re-examine the sample.\n\nSample Input: nums = [6,3,1,2,4,4], k = 7.\n\nThe invalid subarrays are [6,3,1], [6,3,1,2], [6,3,1,2,4], and [6,3,1,2,4,4].\n\nLet's compute the operations required for [6,3,1]:\n\n- 6 > 3: deficit 3. Must add 3 to 3 and 1. So 3*2 = 6 operations.\n- 3 > 1: after adding 3 to 3 and 1, the elements become 6, 6, 4. Now 6 >4: deficit 2. Must add 2 to 4. So 2*1 = 2 operations.\n- Total operations 6 + 2 = 8 > 7. Hence, invalid.\n\nSimilarly, for [6,3,1,2]:\n\n- 6>3: 3*3=9 operations (adding 3 to 3,1,2).\n- 3>1: after adding 3, elements are 6,6,4,5. 6>4: deficit 2. Add 2 to 4 and 5: 2*2=4.\n- 4>5: no deficit.\n- Total 9 +4=13>7. Invalid.\n\nThus, the operations required for a subarray is the sum of deficits, where each deficit is multiplied by the number of elements it affects.\n\nThis suggests that for each subarray, the operations required can be computed as the sum over i from l to r-1 of max(0, (original nums[i] + previous operations) - (original nums[i+1] + previous operations)), but this is complex.\n\nBut this is not feasible for", "To solve this problem, we need to determine the number of subarrays in a given array that can be made non-decreasing by performing at most k operations, where each operation increments an element by 1. The key insight is that for a subarray to be made non-decreasing, the total number of operations required should not exceed k. The challenge is efficiently checking each subarray to see if it meets this condition without resorting to a brute-force approach, which would be computationally infeasible for large arrays.\n\n### Approach\n1. **Understanding Non-decreasing Subarrays with Operations**: For a subarray to be non-decreasing, each element must be at least as large as the previous element. If an element is smaller than the previous one, we need to increment it (and possibly some previous elements) to make the sequence non-decreasing. The total operations required for a subarray is the sum of the differences between each element and the previous element whenever the current element is smaller than the previous one, adjusted for the operations already performed on previous elements.\n\n2. **Sliding Window Technique**: We can use a sliding window approach to efficiently check all possible subarrays. The idea is to maintain a window [left, right] where the subarray can be made non-decreasing with at most k operations. For each right, we expand the window as much as possible while the operations required for the current window do not exceed k. The number of valid subarrays ending at right is then right - left + 1.\n\n3. **Operations Calculation**: For each new element at position right, we compare it with the previous element in the window. If it is smaller, we need to calculate the operations required to make it at least as large as the previous element. This involves keeping track of the required increments in a way that allows us to compute the total operations incrementally as the window expands.\n\n### Solution Code\n```python\nclass Solution:\n    def countNonDecreasingSubarrays(self, nums: List[int], k: int) -> int:\n        n = len(nums)\n        total = 0\n        left = 0\n        operations_used = 0\n        prev = 0\n        \n        for right in range(n):\n            if right > 0:\n                # The required value for nums[right] is at least nums[right-1] (after previous operations)\n                # The required increment is max(0, prev - nums[right])\n                required = max(0, prev - nums[right])\n                operations_used += required\n                \n                # While operations_used exceeds k, move left forward\n                while left < right and operations_used > k:\n                    # When moving left, we need to subtract the operations that were contributed by nums[left] becoming nums[left+1]'s previous\n                    # The original required for nums[left+1] was max(0, nums[left] - nums[left+1])\n                    # But subsequent elements may have been adjusted based on this\n                    # So, the operations_used needs to be adjusted by the difference when left moves\n                    # However, tracking this is complex; alternative approach is to recompute operations_used for the new window\n                    # Recomputing for each new left is O(n^2) in worst case, which is not feasible for large n\n                    # Hence, the initial approach may not work for large n. Need a better way.\n                    pass\n                # Alternative approach: For each new right, compute the operations needed for the subarray ending at right\n                # But this also leads to O(n^2) time.\n                # Hence, the problem requires a more efficient method.\n                pass\n        \n        # The above approach may not work. Let's think differently.\n        # The total number of subarrays is n*(n+1)/2. Subtract the number of subarrays that cannot be made non-decreasing with <=k operations.\n        # So, the problem reduces to finding the number of subarrays that cannot be made non-decreasing with <=k operations.\n        # Then, the answer is total_subarrays - bad_subarrays.\n        \n        total_subarrays = n * (n + 1) // 2\n        bad_subarrays = 0\n        left = 0\n        \n        for right in range(1, n):\n            # For each right, find the left bound such that the subarray [left..right] is bad.\n            # A subarray is bad if the operations needed to make it non-decreasing exceeds k.\n            # The operations needed for a subarray nums[left..right] is sum_{i=left+1..right} max(0, nums[i-1] - nums[i] + delta[i-1]?)\n            # But delta[i-1] is the operations applied to nums[i-1] to make it <= nums[i-2] (if any). This is complex.\n            pass\n        \n        # Another approach inspired by the problem's examples:\n        # The subarrays that cannot be made non-decreasing are those where even after applying operations, the required operations exceed k.\n        # For a subarray to be bad, the sum of the required steps (each step is max(0, nums[i-1] - nums[i])) must exceed k.\n        # But each operation can only increment elements, so the required steps for each i in the subarray is the difference between nums[i-1] (after operations) and nums[i].\n        # The total operations is the sum of (nums[i-1] - nums[i]) for every i where nums[i-1] > nums[i], but after previous operations.\n        # This is equivalent to the sum of (original nums[i-1] + ops[i-1] - original nums[i] - ops[i]) > ... but ops[i] is zero since operations are applied during the process.\n        # So, the total operations required is the sum of (nums[j] - nums[i]) for certain j < i, but this is not straightforward.\n        \n        # Let me think differently. For a subarray starting at l and ending at r, the operations needed is the sum over i from l+1 to r of max(0, (nums[i-1] after ops) - nums[i]).\n        # But the operations applied to nums[i-1] would affect this. So, the total operations is the sum of (max(0, nums[i-1] + ops[i-1] - nums[i])).\n        # But ops[i-1] is the sum of operations applied to nums[i-1], which is the sum of (max(0, nums[i-2] + ops[i-2] - nums[i-1])) and so on.\n        # This recursive relation makes it hard to compute.\n        \n        # However, the operations needed for the subarray is the sum of (max(0, a0 - a1, a1 - a2, ..., a_{m-1} - a_m)), where a_i is the original element plus any operations applied to previous elements.\n        # But this is equivalent to the sum of (max(0, a0 - a1) + max(0, a1 - a2) + ... + max(0, a_{m-1} - a_m)), but after each operation, the previous elements may have been increased.\n        # The minimal total operations required to make the subarray non-decreasing is the sum of (max(0, (original a_{i-1} + previous ops) - original a_i)), but previous ops are the operations applied to a_{i-1} to make it >= a_{i-2}, etc.\n        \n        # This seems to reduce to the following: the minimal operations required is the sum over i of max(0, (original a_{i-1} - original a_i) + (operations applied to a_{i-1})).\n        # But the operations applied to a_{i-1} are the operations needed to make a_{i-1} >= a_{i-2}, which is max(0, a_{i-2} - a_{i-1}) plus operations to a_{i-2}, etc.\n        # This is the same as the operations required to make the entire subarray non-decreasing, which can be computed as follows:\n        # The total operations is the sum over i from 1 to m of max(0, (original a_{i-1} - original a_i) + (operations up to a_{i-1})).\n        # But this is equivalent to the sum of the positive differences between the original array elements, adjusted for the operations applied to previous elements.\n        \n        # The minimal operations required to make a subarray non-decreasing is the sum of (max(0, (original nums[i] - (original nums[i-1] + ops[i-1])))), but this is not directly helpful.\n        \n        # After some research, it turns out that the minimal number of operations to make a subarray non-decreasing is the sum of max(0, nums[i-1] - nums[i]) for all i in the subarray, but this is only true if no operations are applied to previous elements. However, operations can be applied to any element in the subarray, not just the previous one. For example, in the subarray [3, 1, 2], the required operations are 2 (to increment 1 twice), but if we can also increment 3, it might reduce the total operations. But the problem allows incrementing any element in the subarray, so the optimal way is to leave earlier elements as small as possible and increment later elements to meet the non-decreasing condition.\n        \n        # Thus, the minimal operations required is the sum over i from 1 to m of max(0, nums[i-1] - nums[i"]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:54<00:00, 54.91s/it]
Evaluating 2...
  0%|                                                                                                                                                                                                                         | 0/2 [00:00<?, ?it/s]start = 16:49:28.353600
loaded input_output = 16:49:28.597116
loading test code = 16:49:28.597238
start = 16:49:29.822316

Successful compilation of task 0!
loaded input_output = 16:49:29.845870
loading test code = 16:49:29.846026
Results were not True for all test cases curr_res=[False]

Sample

class Solution:
    def countNonDecreasingSubarrays(self, nums: List[int], k: int) -> int:
        n = len(nums)
        total_subarrays = n * (n + 1) // 2
        invalid_subarrays = 0
        left = 0
        
        for right in range(1, n):
            # Calculate the required operations for the new element nums[right]
            # The operations needed is the sum of max(0, nums[i-1] - nums[i]) for i from left+1 to right
            # But we need an efficient way to compute this as right expands
            # We can keep track of the required operations incrementally
            pass
        
        # Alternative approach: for each subarray, check if it can be made non-decreasing with <=k operations
        # But O(n^2) is not feasible for n=1e5
        # So need a sliding window approach
        
        # The correct approach is to find all subarrays where the sum of (max(0, a[i-1] - a[i])) for consecutive elements in the subarray multiplied by the number of times they affect the operations is <=k
        # The sum is sum_{i=l+1 to r} max(0, a[i-1] - a[i]) * (r - i + 1)
        # Because each deficit a[i-1] - a[i] must be added to a[i], a[i+1], ..., a[r] (i ranges from l+1 to r)
        # So the total operations is sum_{i=l+1}^r (a[i-1] - a[i])*(r - i + 1) if a[i-1] > a[i]
        
        # Sliding window approach to count valid subarrays
        res = 0
        left = 0
        current_ops = 0
        
        for right in range(n):
            if right > 0:
                # Calculate the additional operations needed when adding nums[right]
                # The new pairs are (right-1, right)
                if nums[right-1] > nums[right]:
                    diff = nums[right-1] - nums[right]
                    # For each segment that ends at right, the diff affects 1, 2, ..., (right - left) steps?
                    # The number of new subarrays ending at right is (right - left)
                    # So the total operations added is diff * (right - left)
                    # Because for the subarray [left..right], [left+1..right], ..., [right-1..right], each requires diff operations for the last step
                    # So total added operations is diff * (right - left)
                    added_ops = diff * (right - left)
                    current_ops += added_ops
                    
                    # Now, we need to move left forward until current_ops <=k
                    while left <= right and current_ops > k:
                        # When moving left forward, we need to subtract the ops that involved left
                        # For the subarrays that start at left, and end at >= left+1, the ops contributed by nums[left] > nums[left+1]
                        if left < right:
                            if nums[left] > nums[left +1]:
                                diff_left = nums[left] - nums[left +1]
                                # The number of subarrays that start at left and end at any point >= left+1 is (right - left)
                                subtracted_ops = diff_left * (right - left)
                                current_ops -= subtracted_ops
                        left += 1
            # The number of valid subarrays ending at right is right - left + 1
            res += right - left + 1
        
        return res


Result

[False]
******************************


 50%|████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                                                                                        | 1/2 [00:05<00:05,  5.26s/it]
Successful compilation of task 0!
Sample




Result

[-4]
******************************


100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:05<00:00,  2.72s/it]
0.0
```