### PR TITLE
Fix failed tasks empty list of string insertion

### DIFF
--- a/lcb_runner/runner/base_runner.py
+++ b/lcb_runner/runner/base_runner.py
@@ -92,7 +92,7 @@ class BaseRunner(ABC):
                     print("Failed to run the model for some prompts")
                     print(output.status)
                     print(output.exception_tb)
-                    outputs.extend([""] * self.args.n)
+                    outputs.append([""] * self.args.n)
         else:
             outputs = [self.run_single(argument) for argument in
                        tqdm(arguments, progress_file=progress_file_path)]

--- a/lcb_runner/runner/main.py
+++ b/lcb_runner/runner/main.py
@@ -72,7 +72,7 @@ def main():
 
     # If model outputs are empty (probably due to failed inference requests),
     # add args.n empty strings to ensure failed tasks are still evaluated
-    # results = [r if r else [""] * args.n for r in results]
+    results = [r if r else [""] * args.n for r in results]
     combined_results = combine_results(
         args.scenario, results, model, args.cot_code_execution
     )

--- a/lcb_runner/runner/main.py
+++ b/lcb_runner/runner/main.py
@@ -72,7 +72,7 @@ def main():
 
     # If model outputs are empty (probably due to failed inference requests),
     # add args.n empty strings to ensure failed tasks are still evaluated
-    results = [r if r else [""] * args.n for r in results]
+    # results = [r if r else [""] * args.n for r in results]
     combined_results = combine_results(
         args.scenario, results, model, args.cot_code_execution
     )


### PR DESCRIPTION
This will fix an issue related to inserting list of empty strings in the outputs when a task's inference failed (most likely due to API timeout).