### PR TITLE
Extract python code blocks first, and then general code blocks

### DIFF
--- a/lcb_runner/runner/main.py
+++ b/lcb_runner/runner/main.py
@@ -74,7 +74,7 @@ def main():
     # add args.n empty strings to ensure failed tasks are still evaluated
     results = [r if r else [""] * args.n for r in results]
     combined_results = combine_results(
-        args.scenario, results, model, args.cot_code_execution
+        args.scenario, results, model, args.cot_code_execution, args.extraction_strategy
     )
 
     save_results = [

--- a/lcb_runner/runner/parser.py
+++ b/lcb_runner/runner/parser.py
@@ -165,6 +165,14 @@ def get_args():
         help="The directory storing the outputs",
     )
 
+    parser.add_argument(
+        "--extraction_strategy",
+        type=str,
+        default="last-block",
+        choices=["last-block", "last-block-python-first"],
+        help="The code extraction strategy to use. `last-block` extracts the last code block found in the model output. `last-block-python-first` first tries to extract the last python code block, if none found, extracts the last code block.",
+    )
+
     args = parser.parse_args()
 
     args.stop = args.stop.split(",")

--- a/lcb_runner/runner/scenario_router.py
+++ b/lcb_runner/runner/scenario_router.py
@@ -85,12 +85,13 @@ def combine_results(
     results: list[list[str]],
     model: LanguageModel,
     cot_code_execution: bool = False,
+    extraction_strategy: str = "last-block",
 ):
     if scenario == Scenario.codegeneration:
         combined_results = [
             (
                 outputs_list,
-                [extract_code(output, model.model_style) for output in outputs_list],
+                [extract_code(output, model.model_style, extraction_strategy) for output in outputs_list],
             )
             for outputs_list in results
         ]
@@ -114,9 +115,9 @@ def combine_results(
                 ],
                 [
                     (
-                        extract_code(output[0], model.model_style)
+                        extract_code(output[0], model.model_style, extraction_strategy)
                         if type(output) is list
-                        else extract_code(output, model.model_style)
+                        else extract_code(output, model.model_style, extraction_strategy)
                     )
                     for output in outputs_list
                 ],

--- a/lcb_runner/utils/extraction_utils.py
+++ b/lcb_runner/utils/extraction_utils.py
@@ -1,3 +1,5 @@
+import re
+
 from lcb_runner.lm_styles import LMStyle
 
 
@@ -10,11 +12,13 @@ def extract_code(model_output: str, lmstyle: LMStyle):
     elif lmstyle == LMStyle.GenericBase:
         return model_output.strip()
     else:
-        indexlines = [i for i, line in enumerate(outputlines) if "```" in line]
-        if len(indexlines) < 2:
-            return ""
-        # return "\n".join(outputlines[indexlines[0] + 1 : indexlines[1]])
-        return "\n".join(outputlines[indexlines[-2] + 1 : indexlines[-1]])
+        code_blocks = re.findall(r'```python?\n(.*?)```', model_output, re.DOTALL)
+        if code_blocks:
+            return code_blocks[-1].strip()
+        code_blocks = re.findall(r'```\n(.*?)```', model_output, re.DOTALL)
+        if code_blocks:
+            return code_blocks[-1].strip()
+        return ""
 
 
 def extract_test_output_code(model_output: str, lmstyle: LMStyle = None):

--- a/lcb_runner/utils/extraction_utils.py
+++ b/lcb_runner/utils/extraction_utils.py
@@ -3,7 +3,7 @@ import re
 from lcb_runner.lm_styles import LMStyle
 
 
-def extract_code(model_output: str, lmstyle: LMStyle):
+def extract_code(model_output: str, lmstyle: LMStyle, extraction_strategy: str = "last-block"):
     outputlines = model_output.split("\n")
     if lmstyle == LMStyle.CodeLLaMaInstruct:
         indexlines = [i for i, line in enumerate(outputlines) if "PYTHON]" in line]
@@ -12,9 +12,10 @@ def extract_code(model_output: str, lmstyle: LMStyle):
     elif lmstyle == LMStyle.GenericBase:
         return model_output.strip()
     else:
-        code_blocks = re.findall(r'```python?\n(.*?)```', model_output, re.DOTALL)
-        if code_blocks:
-            return code_blocks[-1].strip()
+        if extraction_strategy == "last-block-python-first":
+            code_blocks = re.findall(r'```python?\n(.*?)```', model_output, re.DOTALL)
+            if code_blocks:
+                return code_blocks[-1].strip()
         code_blocks = re.findall(r'```\n(.*?)```', model_output, re.DOTALL)
         if code_blocks:
             return code_blocks[-1].strip()


### PR DESCRIPTION
This PR will modify the code_extract function of LCB. Instead of looking for triple backticks without language specification and picking the last code block, this PR will first look for python code blocks and use the last found one. If nothing is found, it then looks for code blocks without language specification pattern.

This fixes an issue where the model provides some more details, reasonings, or examples inside triple backticks after generating the soultion.